### PR TITLE
Fix golangci-lint issues for CI compliance

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,8 @@ func Load(configPath string) (*Config, error) {
 
 			// Create config directory if it doesn't exist
 			if _, err := os.Stat(configDir); os.IsNotExist(err) {
-				os.MkdirAll(configDir, 0755)
+				// Ignore errors - config file is optional, user can still use env vars
+				_ = os.MkdirAll(configDir, 0755)
 			}
 
 			// Use config file if it exists

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -47,7 +47,7 @@ func ServeHTTP(mcpServer *server.MCPServer, port int, authToken string) error {
 func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"healthy","service":"ynab-mcp-server"}`))
+	_, _ = w.Write([]byte(`{"status":"healthy","service":"ynab-mcp-server"}`))
 }
 
 // rootHandler provides basic server information
@@ -59,7 +59,7 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`YNAB MCP Server
+	_, _ = w.Write([]byte(`YNAB MCP Server
 
 This is a Model Context Protocol (MCP) server for YNAB (You Need A Budget).
 
@@ -82,7 +82,7 @@ func authMiddleware(next http.Handler, expectedToken string) http.Handler {
 			slog.Warn("Unauthorized request", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error":"Unauthorized","message":"Valid Bearer token required"}`))
+			_, _ = w.Write([]byte(`{"error":"Unauthorized","message":"Valid Bearer token required"}`))
 			return
 		}
 

--- a/internal/tools/transactions.go
+++ b/internal/tools/transactions.go
@@ -184,7 +184,7 @@ func NewGetTransactionTool(client *ynab.Client) ToolDefinition {
 		}
 
 		var result strings.Builder
-		result.WriteString(fmt.Sprintf("Transaction Details\n\n"))
+		result.WriteString("Transaction Details\n\n")
 		result.WriteString(fmt.Sprintf("Date: %s\n", tx.Date))
 		result.WriteString(fmt.Sprintf("Payee: %s\n", tx.PayeeName))
 		result.WriteString(fmt.Sprintf("Amount: %s\n", ynab.FormatCurrency(tx.Amount)))
@@ -196,7 +196,7 @@ func NewGetTransactionTool(client *ynab.Client) ToolDefinition {
 			result.WriteString(fmt.Sprintf("Memo: %s\n", tx.Memo))
 		}
 
-		result.WriteString(fmt.Sprintf("\nStatus:\n"))
+		result.WriteString("\nStatus:\n")
 		result.WriteString(fmt.Sprintf("  Cleared: %s\n", tx.Cleared))
 		result.WriteString(fmt.Sprintf("  Approved: %t\n", tx.Approved))
 		if tx.FlagColor != "" {

--- a/internal/ynab/client.go
+++ b/internal/ynab/client.go
@@ -128,13 +128,3 @@ func (c *Client) post(path string, body interface{}, result interface{}) error {
 func (c *Client) put(path string, body interface{}, result interface{}) error {
 	return c.doRequest("PUT", path, body, result)
 }
-
-// patch performs a PATCH request
-func (c *Client) patch(path string, body interface{}, result interface{}) error {
-	return c.doRequest("PATCH", path, body, result)
-}
-
-// delete performs a DELETE request
-func (c *Client) delete(path string) error {
-	return c.doRequest("DELETE", path, nil, nil)
-}


### PR DESCRIPTION
## Summary

This PR resolves all golangci-lint issues identified in the CI pipeline, ensuring code passes linting checks across all platforms.

## Changes Made

### Error Handling
- **`internal/config/config.go`**: Added explicit error handling for `os.MkdirAll` with documented ignore (config file is optional)
- **`internal/server/http.go`**: Added proper handling for `http.ResponseWriter.Write` return values in:
  - `healthCheckHandler` 
  - `rootHandler`
  - `authMiddleware`

### Code Cleanup
- **`internal/ynab/client.go`**: Removed unused `patch()` and `delete()` helper methods
- **`internal/tools/transactions.go`**: Simplified string literals by removing unnecessary `fmt.Sprintf` calls

## Testing

- ✅ All linting checks pass: `golangci-lint run`
- ✅ No test failures: `go test ./...`
- ✅ Changes maintain existing functionality

## Impact

These changes are purely cosmetic/compliance fixes with no functional changes to the codebase. All existing behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)